### PR TITLE
Address issues detected by golangci-lint

### DIFF
--- a/bot/gerrit.go
+++ b/bot/gerrit.go
@@ -108,12 +108,17 @@ func (b *Bot) updateCL(ctx context.Context, key *datastore.Key, cl *storedCL) er
 
 func (b *Bot) processCLList(ctx context.Context, lastID int, span *trace.Span) int {
 	req, err := http.NewRequest("GET", b.gerritLink, nil)
+	if err != nil {
+		b.logf("failed to build GET request to %q: %v\n", b.gerritLink, err)
+		return lastID
+	}
+
 	req.Header.Add("User-Agent", "Gophers Slack bot")
 	req = req.WithContext(ctx)
 
 	resp, err := b.client.Do(req)
 	if err != nil {
-		b.logf("%s\n", err)
+		b.logf("failed to get data from Gerrit: %v\n", err)
 		return lastID
 	}
 
@@ -162,7 +167,7 @@ func (b *Bot) processCLList(ctx context.Context, lastID int, span *trace.Span) i
 	for idx := foundIdx - 1; idx >= 0; idx-- {
 		cl := cls[idx]
 
-		if shown, err := b.wasShown(ctx, cl); err == nil {
+		if shown, wserr := b.wasShown(ctx, cl); wserr == nil {
 			if shown {
 				continue
 			}
@@ -229,7 +234,7 @@ func shareCL(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 			b.logf("could not convert string to int: %v from event: %#v\n", err, event)
 
 			params := slack.PostMessageParameters{AsUser: true}
-			_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
+			_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
 			if err != nil {
 				b.logf("%s\n", err)
 			}
@@ -243,7 +248,7 @@ func shareCL(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 			b.logf("error while retriving CL from the DB: %v\n", err)
 
 			params := slack.PostMessageParameters{AsUser: true}
-			_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
+			_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
 			if err != nil {
 				b.logf("%s\n", err)
 			}
@@ -252,7 +257,7 @@ func shareCL(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 
 		if cl.Tweeted {
 			params := slack.PostMessageParameters{AsUser: true}
-			_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Already tweeted CL %d`, clNumber), params)
+			_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Already tweeted CL %d`, clNumber), params)
 			if err != nil {
 				b.logf("%s\n", err)
 			}
@@ -265,7 +270,7 @@ func shareCL(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 			b.logf("got error while tweeting CL: %d %#v\n", clNumber, err)
 
 			params := slack.PostMessageParameters{AsUser: true}
-			_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
+			_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
 			if err != nil {
 				b.logf("%s\n", err)
 			}


### PR DESCRIPTION
Here is the full list of items detected by `golangci-lint`, with the ones
detected by `errcheck` and `golint` ignored for now. The ones detected by
`megacheck` were already addressed in #43, and so I don't address them in this
PR.

```
bot/bot.go:585:17: Error return value of `resp.Body.Close` is not checked (errcheck)
        resp.Body.Close()
                       ^
bot/bot.go:608:23: Error return value of `resp.Body.Close` is not checked (errcheck)
        defer resp.Body.Close()
                             ^
bot/bot.go:679:23: Error return value of `resp.Body.Close` is not checked (errcheck)
        defer resp.Body.Close()
                             ^
gopher.go:131:22: Error return value of `dsClient.Close` is not checked (errcheck)
        defer dsClient.Close()
                            ^
bot/bot.go:96:2: ineffectual assignment to `publicChannels` (ineffassign)
        publicChannels = nil
        ^
bot/bot.go:100:13: ineffectual assignment to `err` (ineffassign)
        botGroups, err := b.slackBotAPI.GetGroupsContext(ctx, true)
                   ^
bot/bot.go:110:2: ineffectual assignment to `botGroups` (ineffassign)
        botGroups = nil
        ^
bot/bot.go:573:7: ineffectual assignment to `err` (ineffassign)
        req, err := http.NewRequest("GET", info.URLPrivateDownload, nil)
             ^
bot/gerrit.go:110:7: ineffectual assignment to `err` (ineffassign)
        req, err := http.NewRequest("GET", b.gerritLink, nil)
             ^
bot/gerrit.go:165:13: declaration of "err" shadows declaration at bot/gerrit.go:110 (govet)
                if shown, err := b.wasShown(ctx, cl); err == nil {
                          ^
bot/gerrit.go:232:10: declaration of "err" shadows declaration at bot/gerrit.go:227 (govet)
                        _, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
                              ^
bot/gerrit.go:246:10: declaration of "err" shadows declaration at bot/gerrit.go:227 (govet)
                        _, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Could not share CL %d, please try again`, clNumber), params)
                              ^
bot/gerrit.go:255:10: declaration of "err" shadows declaration at bot/gerrit.go:227 (govet)
                        _, _, err := b.slackBotAPI.PostMessageContext(ctx, event.User, fmt.Sprintf(`Already tweeted CL %d`, clNumber), params)
                              ^
gopher.go:134:5: declaration of "err" shadows declaration at gopher.go:106 (govet)
        if err := b.Init(ctx, slackBotRTM, startupSpan); err != nil {
           ^
bot/gerrit.go:69:1: exported method Bot.GetLastSeenCL should have comment or be unexported (golint)
func (b *Bot) GetLastSeenCL(ctx context.Context) (int, error) {
^
bot/gotimefm.go:17:1: exported method Bot.GoTimeFM should have comment or be unexported (golint)
func (b *Bot) GoTimeFM() {
^
gopher.go:111:2: var traceHttpClient should be traceHTTPClient (golint)
        traceHttpClient := traceClient.NewHTTPClient(httpClient)
        ^
bot/bot.go:829:23: should use make([]byte, 1) instead (megacheck)
        buff := make([]byte, 1, 1)
                             ^
bot/bot.go:839:67: the argument is already a string, there's no need to use fmt.Sprintf (megacheck)
        _, _, err = b.slackBotAPI.PostMessageContext(ctx, event.Channel, fmt.Sprintf("%s", result), params)

```

Signed-off-by: Tim Heckman <t@heckman.io>