### PR TITLE
Apply message options consistently

### DIFF
--- a/bot/gerrit.go
+++ b/bot/gerrit.go
@@ -178,9 +178,8 @@ func (b *Bot) processCLList(ctx context.Context, lastID int, span *trace.Span) i
 			return lastID
 		}
 
-		_, _, err = b.slackBotAPI.PostMessageContext(ctx, pubChannel,
-			slack.MsgOptionAsUser(true),
-			slack.MsgOptionText(fmt.Sprintf("[%d] %s: %s", cl.Number, cl.message(), cl.link()), false),
+		msg := fmt.Sprintf("[%d] %s: %s", cl.Number, cl.message(), cl.link())
+		err = b.postMessage(ctx, pubChannel, msg,
 			slack.MsgOptionAttachments(slack.Attachment{
 				Title:     cl.Subject,
 				TitleLink: cl.link(),

--- a/bot/gotimefm.go
+++ b/bot/gotimefm.go
@@ -6,8 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
-
-	"github.com/nlopes/slack"
 )
 
 type goTimeFMStatus struct {
@@ -47,10 +45,7 @@ func (b *Bot) GoTimeFM() {
 	timeNow := time.Now()
 	if status.Streaming && timeNow.Sub(b.goTimeLastNotified).Hours() > 24 {
 		b.goTimeLastNotified = timeNow
-		_, _, err := b.slackBotAPI.PostMessageContext(ctx, b.channels["gotimefm"].slackID,
-			slack.MsgOptionAsUser(true),
-			slack.MsgOptionText(":tada: GoTimeFM is now live :tada:", false),
-		)
+		err := b.postMessage(ctx, b.channels["gotimefm"].slackID, ":tada: GoTimeFM is now live :tada:")
 		if err != nil {
 			b.logf("got error while notifying slack: %s\n", err)
 		}


### PR DESCRIPTION
API upgrade seems to have caused unfurls where there weren't before. Correct by using a consistent set of default message options where applicable.